### PR TITLE
Adds additional check to make sure JSON object is valid when IP lookup error occurs

### DIFF
--- a/jarm.py
+++ b/jarm.py
@@ -511,7 +511,10 @@ def main():
             else:
                 file.write(destination_host + "," + ip + "," + result)
         else:
-            file.write(destination_host + ",Failed to resolve IP," + result)
+            if args.json:
+                file.write('{"host":"' + destination_host + '","ip":"' + 'Failed to resolve IP' + '","result":"' + result + '"')
+            else:
+                file.write(destination_host + ",Failed to resolve IP," + result)
         #Verbose mode adds pre-fuzzy-hashed JARM
         if args.verbose:
             if args.json:


### PR DESCRIPTION
JSON object building logic is partially broken when outputting to a file.
This additional check fixes that issue (See also below for an example scan of a non-existing domain before and after the correction).

![image](https://github.com/salesforce/jarm/assets/17042203/6f81b31b-67e4-48ad-8c1a-cedb18d979e4)
